### PR TITLE
fixed issue #156

### DIFF
--- a/bedes-backend/src/bedes/query/bedes-unit/index.ts
+++ b/bedes-backend/src/bedes/query/bedes-unit/index.ts
@@ -86,7 +86,7 @@ export class BedesUnitQuery {
      */
     public getRecordById(unitId: number, transaction?: any): Promise<IBedesUnit> {
         try {
-            if (!unitId) {
+            if (unitId == null) {
                 logger.error(`${this.constructor.name}: Missing unitId in BedesUnit-getRecordById`);
                 throw new Error('Missing required parameters.');
             }


### PR DESCRIPTION
"!unitId" is true for unitId = 0. Changed it to "unitId == null" instead, which correctly checks for null and undefined values only.